### PR TITLE
2016-06-13 new about.md section; moved contact.md to about.md

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: 'About'
+meta_title: "Join the discussion"
+subheadline: "Join the discussion"
+teaser: "Here's how to connect with the community"
+permalink: '/about/'
+---
+
+## About InnerSourceCommons.org
+InnerSourceCommons.org (aka ISC) utilizes open source methods to provide organizations pursuing inner sourcing a forum for discussing and improving the practice of inner source through the sharing of experiences (under the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule)), creation and review of inner source patterns, and the open exchange of ideas.
+
+Interested individuals and companies are welcome to participate and contribute content to the ISC. In general, contributed content will be made available under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/) attributed to InnerSourceCommons.org. No fees are required to participate.
+
+The ISC was founded by PayPal in 2015.
+
+## Contact Information
+* Email <questions@innersourcecommons.org>
+* Join the [#innersourcecommons](https://isc-inviter.herokuapp.com/) slack channel
+
+## Licensing
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">InnerSourceCommons.org</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="innersourcecommons.org" property="cc:attributionName" rel="cc:attributionURL">InnerSourceCommons.org</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://innersourcecommons.org" rel="dct:source">http://innersourcecommons.org</a>.


### PR DESCRIPTION
Creating a new About page to replace the Contact one (an integrate the Contact info therein). The About page holds information about ISC and how participants interact (Chatham House Rule) as well as shows the CC BY-SA licensing.