### PR TITLE
Fixed syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ TODO: Add contributing guidelines.
 * Install ruby
 * Install bundler gem
 * Run 'bundle install'
-* Run 'jekyll build -s <master branch location> -d <gh-pages location>'
-* Copy README.md from <master branch location> to <gh-pages location>
+* Run 'jekyll build -s &lt;master branch location&gt; -d &lt;gh-pages location&gt;'
+* Copy README.md from &lt;master branch location&gt; to &lt;gh-pages location&gt;

--- a/_includes/_navigation.html
+++ b/_includes/_navigation.html
@@ -106,7 +106,7 @@
                         {% assign domain = site.url %}
                       {% endif %}
 
-                      <li><a href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}"{% if dropdown_link.url contains 'http' %} target="_blank"{% endif %}>{{ dropdown_link.title | escape }}</a></li>
+                      <li><a {% if dropdown_link.url contains 'http' %} target="_blank" href="{{ dropdown_link.url }}" {% else %} href="{{ domain }}{{ site.baseurl }}{{ dropdown_link.url }}" {% endif %}>{{ dropdown_link.title | escape }}</a></li>
                     {% endfor %}
                   </ul>
 


### PR DESCRIPTION
I know it seems small but this is my first PR ever and i'm just trying to get my feet wet. I noticed when i was trying to build the site that the build instructions looked strange and then i inspected the markdown and saw why. I also fixed the broken wiki link by patching the logic in _includes/_navigation.html. 