### PR TITLE
Add 2 needed links on frontpage sidebar

### DIFF
--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -2,7 +2,7 @@
 	<div class="panel radius">
 		<h3><a href="/InnerSourceCommons/events/isc-fall-2016/">ISC Summit</a></h3>
 		<p>
-		  Please join us at the next InnerSource Commons Summit! We will be meeting September 28-30 in Boston, USA.
+		  Please join us at the next <a href="/InnerSourceCommons/events/isc-fall-2016/">InnerSource Commons Summit</a>! We will be meeting September 28-30 in Boston, USA. Signup <a href="https://www.eventbrite.com/e/innersource-commons-summit-fall-2016-tickets-26666521283">here</a>.
 		</p>
 	</div>
 


### PR DESCRIPTION
Added two links on the frontpage sidebar - one for UX concerns that made it hard to quickly get to more info on the summit, and one link to signup at eventbrite