### PR TITLE
Create CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+innersourcecommons.org


### PR DESCRIPTION
Handle hosting at InnerSourceCommons.org rather than redirecting to the paypal.github.io/innersourcecommons URL.

More information: https://help.github.com/articles/using-a-custom-domain-with-github-pages/