### PR TITLE
2017-08-03 - fixing the speakers page; adding a link to agenda

### DIFF
--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -7,7 +7,7 @@
 	</div>
     <div class="panel radius">
         <h3><a href="http://www.oreilly.com/pub/e/3884">O'Reilly Webinar</a></h3>
-        <p>Learn about <a href="https://github.com/paypal/InnerSourcePatterns">InnerSource Patterns</a> at <em>Implementing InnerSource Patterns: Solve Organizational Problems by Leveraging Community Contributions</em>, Thursday, June 1, 2017; the replay video is now available.
+        <p>Learn about <a href="https://github.com/paypal/InnerSourcePatterns">InnerSource Patterns</a> by watching the replay of the <em>Implementing InnerSource Patterns: Solve Organizational Problems by Leveraging Community Contributions</em> webinar from Thursday, June 1, 2017.
         </p>
     </div>
 

--- a/events/isc-fall-2017-agenda.md
+++ b/events/isc-fall-2017-agenda.md
@@ -3,6 +3,7 @@ layout: page-fullwidth
 title: 'InnerSource Commons Fall Summit 2017 Agenda'
 ---
 
-[Return to the Fall Summit 2017 page](/InnerSourceCommons/events/isc-fall-2017/)
+[[Return to the Fall Summit 2017 page](/InnerSourceCommons/events/isc-fall-2017/)]
+[[See the speakers](/InnerSourceCommons/events/isc-fall-2017-speakers/)]
 
 <iframe src="https://docs.google.com/document/d/e/2PACX-1vSXM7thBkbO4nqIuG_vu6h8gYVI65uJMIMPfImdeTSzXUBKVl5WXbbN1ZHADZv1tEZ5V8FUm5d8otFg/pub?embedded=true" width="960" height="4750"></iframe>

--- a/events/isc-fall-2017-speakers.md
+++ b/events/isc-fall-2017-speakers.md
@@ -3,6 +3,7 @@ layout: page-fullwidth
 title: 'InnerSource Commons Fall Summit 2017 Speakers'
 ---
 
-[Return to the Fall Summit 2017 page](/InnerSourceCommons/events/isc-fall-2017/)
+[[Return to the Fall Summit 2017 page](/InnerSourceCommons/events/isc-fall-2017/)]
+[[See the agenda](/InnerSourceCommons/events/isc-fall-2017-agenda/)]
 
-<iframe width="960" height="3900" src="https://docs.google.com/document/d/e/2PACX-1vRaHfTleJAKWYUQd8R5sd_44HuBMJ_m6ZvI3LPVbgD5G8v4qNBhhOtDOhEkgjT7IiVkAAMBJutfjJzO/pub?embedded=true"></iframe>
+<iframe width="960" height="5200" src="https://docs.google.com/document/d/e/2PACX-1vRaHfTleJAKWYUQd8R5sd_44HuBMJ_m6ZvI3LPVbgD5G8v4qNBhhOtDOhEkgjT7IiVkAAMBJutfjJzO/pub?embedded=true"></iframe>

--- a/events/isc-fall-2017.md
+++ b/events/isc-fall-2017.md
@@ -5,7 +5,7 @@ title: 'InnerSource Commons Fall Summit 2017'
 
 ### September 27-29 Wed-Fri in Chicago (Naperville, IL), USA
 
-Join us for the InnerSource Commons Fall Summit 2017 in Naperville, IL, USA.  Naperville is a western suburb of Chicago, about 45 minutes from the Loop.
+Join us for the InnerSource Commons Fall Summit 2017 in Naperville, IL, USA.  Naperville is a western suburb of Chicago, about 45 minutes from the Loop. We have [a great slate of speakers](/InnerSourceCommons/events/isc-fall-2017-speakers) and [a solid line-up of presentations and workshops](/InnerSourceCommons/events/isc-fall-2017-agenda).
 
 There is an optional, free Ignite Talks class on the 26th available to Summit attendees. Look for the link when you submit your registration.
 


### PR DESCRIPTION
The speakers page needed some fixes (increased the length of the iframe to remove the secondary scrollbar); added a link to the agenda to point to the speakers page. Added links to the Fall 2017 summit to the speakers and agenda pages. And slightly updated the wording for the webinar link on the sidebar.