### PR TITLE
2018-04-10 updated CFP end date

### DIFF
--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -4,7 +4,7 @@
 		<p>
         Join us at the <a href="/InnerSourceCommons/events/isc-spring-2018/">spring 2018 summit</a> May 16-18, 2018! We have an agenda packed with interesting <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2018-speakers" alt="Our speakers">speakers</a> and <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2018-agenda" alt="Our presentations">presentations</a>. We're looking forward to meet you in Renningen, Germany.</p>
 		<p>
-		  The <a href="/InnerSourceCommons/events/isc-fall-2018/">fall 2018 summit</a> will be October 3-5 in Islandia, New York, USA. The <a href="/InnerSourceCommons/events/isc-fall-2018-cfp/">Call For Papers</a> is now open through May 2018.
+		  The <a href="/InnerSourceCommons/events/isc-fall-2018/">fall 2018 summit</a> will be October 3-5 in Islandia, New York, USA. The <a href="/InnerSourceCommons/events/isc-fall-2018-cfp/">Call For Papers</a> is now open through June 2018.
 		</p>
 	</div>
     <div class="panel radius">

--- a/events/isc-fall-2018.md
+++ b/events/isc-fall-2018.md
@@ -7,7 +7,7 @@ title: 'InnerSource Commons Fall Summit 2018'
 
 ### Call For Presentations
 
-See the [Call For Presentations for the 2018 Fall Summit](/InnerSourceCommons/events/isc-fall-2018-cfp), which will be open through May 2018.
+See the [Call For Presentations for the 2018 Fall Summit](/InnerSourceCommons/events/isc-fall-2018-cfp), which will be open through June 2018.
 
 
 ### Registration


### PR DESCRIPTION
Moved it from May 2018 to June 2018 on the sidebar and on the fall 2018 page.