### PR TITLE
Add Call for Posters re:Spring Summit 2018 to Website

### DIFF
--- a/events/isc-spring-2018.md
+++ b/events/isc-spring-2018.md
@@ -9,6 +9,10 @@ title: 'InnerSource Commons Spring Summit 2018'
 Please [register now](https://www.eventbrite.com/e/6th-innersource-commons-summit-tickets-42722496136) for the 6th InnerSource Commons. We will donate the
 conference proceeds to the [Apache Software Foundation](http://apache.org).
 
+### Call for posers is now open
+
+During the summit, we will perform a poster session: Participants will gather around posters and have discussions with the authors of these posters. Use [this form](https://docs.google.com/forms/d/e/1FAIpQLSe9jmvR1bhtQ8MSqXEvmYbG6tn3AkS7IL7BsMJWRpZOgH8asw/viewform?usp=sf_link) to submit a poster for the InnerSource Commons Spring Summit 2018 before May 7th, 2018.
+
 ### Agenda and speakers
 
 See the [agenda](/InnerSourceCommons/events/isc-spring-2018-agenda) and see all [our speakers](/InnerSourceCommons/events/isc-spring-2018-speakers)

--- a/pages/springsummit2018_cfposters.md
+++ b/pages/springsummit2018_cfposters.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource Spring Summit 2018 Call for Presentations'
+permalink: "/springsummit2018_cfposters/"
+redirect_to: 
+    - https://docs.google.com/forms/d/e/1FAIpQLSe9jmvR1bhtQ8MSqXEvmYbG6tn3AkS7IL7BsMJWRpZOgH8asw/viewform?usp=sf_link
+---


### PR DESCRIPTION
This merge requests adds the call for posters regarding the Spring Summit 2018 to the commons website. 

1. It defines the shortcut url `innersourcecommons.org/springsummit2018_cfposters`

2. It links the call for paper form on the spring summit's main page

Note: This time, the form linked and not put in an `<iframe>` tag. This is because the iframe would break Google form's "file upload" popup.