### PR TITLE
Fixed broken link on ISC Fall Summit page

### DIFF
--- a/events/isc-fall-2018.md
+++ b/events/isc-fall-2018.md
@@ -51,7 +51,7 @@ Otto earned a bachelor’s degree in physics from Middlebury College in Vermont 
 <b>Mary Lynn Manns, PhD and Author</b>
 
 <p>
-Dr. Mary Lynn Manns is a professor in the Department of Management at UNC Asheville and the co-author of two books, <i>Fearless Change: Patterns for Introducing New Ideas</i>, 2005 (also published in Japanese and Chinese) and <i>More Fearless Change: Strategies for Making Your Ideas Happen</i>, 2015. Mary Lynn has given numerous presentations on change leadership throughout the world in many organizations that include Microsoft, Proctor & Gamble, Avon, and amazon.com.  On campus, she coordinates the "Ideas to Action" initiative at UNC Asheville, which guides students as they work in interdisciplinary teams to design, develop, and defend their ideas for changing the world. Click [here](https://mgmtacct.unca.edu/faces/mary-lynn-manns-phd) for more information. 
+Dr. Mary Lynn Manns is a professor in the Department of Management at UNC Asheville and the co-author of two books, <i>Fearless Change: Patterns for Introducing New Ideas</i>, 2005 (also published in Japanese and Chinese) and <i>More Fearless Change: Strategies for Making Your Ideas Happen</i>, 2015. Mary Lynn has given numerous presentations on change leadership throughout the world in many organizations that include Microsoft, Proctor & Gamble, Avon, and amazon.com.  On campus, she coordinates the "Ideas to Action" initiative at UNC Asheville, which guides students as they work in interdisciplinary teams to design, develop, and defend their ideas for changing the world. For more information: https://mgmtacct.unca.edu/faces/mary-lynn-manns-phd. 
 </p>
 </td>
 


### PR DESCRIPTION
The "click here" link for Mary Lynn's bio was broken, so I reformatted.