### PR TITLE
Added, wired in Learning Path page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -23,6 +23,8 @@
     url: "/resources/articles/"
   - title: "Books"
     url: "/resources/books"
+  - title: "Learning Path"
+    url: "/resources/learningpath/"
   - title: "Wiki"
     url: "https://github.com/paypal/InnerSourceCommons/wiki"
   - title: "Patterns"

--- a/resources/learningpath.md
+++ b/resources/learningpath.md
@@ -1,0 +1,23 @@
+---
+layout: page
+show_meta: false
+title: 'Learning Path'
+---
+
+The Inner Source Learning Path is a series of short videos and articles explaining and teaching various aspects of inner source.
+Their production was kindly sponsored by PayPal. The Learning Path section introducing Inner Source is already shot and hosted in the O'Reilly Safari platform at http://bit.ly/inner-source-learning-path.
+
+Once finished, the first edition of the Inner Source Learning Path will cover the following sections:
+
+1. Introduction
+1. Product Owner *(coming soon...)*
+1. Trusted Committer *(coming soon...)*
+1. Contributor *(comming soon...)*
+
+
+## Contribute to the Inner Source Learning Paths!
+
+We invite you to help us finishing the Inner Source Learning Paths. Checkout the [README.md of the Learning Path Repository](https://github.com/InnerSourceCommons/InnerSourceLearningPath/) or join our Slack channel via the signup link in the left bar of this website and ask to join the [#learning-path] _Slack_ channel.
+
+[InnerSource Commons]: http://www.innersourcecommons.org/
+[#learning-path]: https://paypalflow.slack.com/messages/CARTU4XV2


### PR DESCRIPTION
This pull request adds a page for the Inner Source Learning Path to innersourcecommons.org. 

Most text fragments are borrowed from @rrrutledge's README.md 