### PR TITLE
2019-01-07 Clean-up of _sidebar and events index

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,10 +10,10 @@
   url: "/events/"
   side: left
   dropdown:
+  - title: "EU Summit Spring 2019"
+    url: "/events/isc-spring-2019"
   - title: "US Summit Fall 2018"
     url: "/events/isc-fall-2018"
-  - title: "EU Summit Spring 2018"
-    url: "/events/isc-spring-2018"
     
 - title: Resources
   url: "/resources/"

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -2,10 +2,7 @@
 	<div class="panel radius">
 		<h3><a href="/InnerSourceCommons/events/">ISC Events</a></h3>
 		<p>
-        The <a href="/InnerSourceCommons/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/InnerSourceCommons/events/isc-fall-2018/">ISC.S7 event page</a>. Please watch this site for details on the upcoming 2019 Spring (April) and Fall summits!
-    <p>
-        The <a href="/InnerSourceCommons/events/isc-spring-2018/">spring 2018 summit</a> May 16-18, 2018 is now over, with its agenda packed with interesting <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2018-speakers" alt="Our speakers">speakers</a> and <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2018-agenda" alt="Our presentations">presentations</a>. The group photo from Renningen, Germany as well as links to videos have been added to the <a href="/InnerSourceCommons/events/isc-spring-2018/">ISC.S6 event page</a>, now.</p>
-	
+        The <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
 		</p>
 	</div>
     <div class="panel radius">

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,7 +1,7 @@
 <aside>
 	<div class="panel radius">
 		<h3><a href="/InnerSourceCommons/events/">ISC Events</a></h3>
-        The <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
+        The <a href="/InnerSourceCommons/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
 		</p>
         <p>The <a href="/InnerSourceCommons/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/InnerSourceCommons/events/isc-fall-2018/">ISC.S7 event page</a>.</p>
         <p><a href="/events">Information on past events</a> is available.</p>

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,9 +1,10 @@
 <aside>
 	<div class="panel radius">
 		<h3><a href="/InnerSourceCommons/events/">ISC Events</a></h3>
-		<p>
         The <a href="http://paypal.github.io/InnerSourceCommons/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
 		</p>
+        <p>The <a href="/InnerSourceCommons/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/InnerSourceCommons/events/isc-fall-2018/">ISC.S7 event page</a>.</p>
+        <p><a href="/events">Information on past events</a> is available.</p>
 	</div>
     <div class="panel radius">
         <h3><a href="http://www.oreilly.com/pub/e/3884">O'Reilly Webinar</a></h3>

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -4,7 +4,7 @@
         The <a href="/InnerSourceCommons/events/isc-spring-2019/">Spring 2019 summit</a> will be held in Galway, Ireland from 9-11 April 2019. We look forward to another exciting lineup and thought leadership speakers. Hope to see you there! 	
 		</p>
         <p>The <a href="/InnerSourceCommons/events/isc-fall-2018/">Fall 2018 summit</a> October 3-5, is now over, with its impressive <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-agenda" alt="Agenda">Agenda</a> and exciting lineup of <a href="http://paypal.github.io/InnerSourceCommons/events/isc-fall-2018-speakers" alt="Speakers"> Speakers</a> and thought leadership. The group photo from Islandia, NY is now on the <a href="/InnerSourceCommons/events/isc-fall-2018/">ISC.S7 event page</a>.</p>
-        <p><a href="/events">Information on past events</a> is available.</p>
+        <p><a href="/InnerSourceCommons/events">Information on past events</a> is available.</p>
 	</div>
     <div class="panel radius">
         <h3><a href="http://www.oreilly.com/pub/e/3884">O'Reilly Webinar</a></h3>

--- a/events/index.md
+++ b/events/index.md
@@ -4,14 +4,14 @@ title: 'Upcoming InnerSource Events'
 ---
 
 ## Current Events
-
-* [Commons Summit 7 - Fall 2018](isc-fall-2018)
-   - InnerSource Commons Summit 7 - New York, USA - Oct 3-5
+* [Commons Summit 8 - Spring 2018](isc-spring-2019)
+   - InnerSource Commons Summit 7 - Galway, Ireland - April 9-11
 
 ## Upcoming Events
 
 ## Prior Events
-
+* [Commons Summit 7 - Fall 2018](isc-fall-2018)
+   - InnerSource Commons Summit 7 - New York, USA - Oct 3-5
 * [Commons Summit 6 - Spring 2018](isc-spring-2018)
     - InnerSource Commons Summit - Germany - May 16-18
 * [Commons Summit - Fall 2017](isc-fall-2017)

--- a/events/isc-spring-2019.md
+++ b/events/isc-spring-2019.md
@@ -6,8 +6,9 @@ title: 'InnerSource Commons Spring Summit 2019'
 ### 9th to 11th April 2019 in Galway, Ireland
 
 ### Call For Presentations
-Use this form to submit your proposal for the InnerSource Commons Spring Summit 2019:https://tinyurl.com/ycuxbjbe
-All proposals are due by midnight, February 10th, 2019. All presentations at the Spring Summit, unless otherwise designated by the presenter, will be covered by the Chatham House Rule. See https://www.chathamhouse.org/about/chatham-house-rule 
+Use this form to submit your proposal [here](https://tinyurl.com/ycuxbjbe) for the InnerSource Commons Spring Summit 2019
+
+All proposals are due by midnight, February 10th, 2019. All presentations at the Spring Summit, unless otherwise designated by the presenter, will be covered by the Chatham House Rule. See the [Chatham House Rule](https://www.chathamhouse.org/about/chatham-house-rule). 
 
 ### Registration
 Details will be released shortly.
@@ -32,7 +33,7 @@ The three key reasons to attend the InnerSource Common Summits are:
 * Network, network, network! The InnerSource Commons is an excellent place to network with likeminded people, all of whom are passionate about making InnerSource a success in their respective organizations!
 
 ### Venue
-This Summit is hosted by the National University of Ireland, Galway (NUIG) at the North Campus in the J.E Cairnes Building. A full interactive campus map is also available at: https://www.nuigalway.ie/campus-map/
+This Summit is hosted by the National University of Ireland, Galway (NUIG) at the North Campus in the J.E Cairnes Building. A full interactive campus map is also available at: [www.nuigalway.ie/campus-map/](https://www.nuigalway.ie/campus-map/)
 
 ### Travel and Transit
 
@@ -53,9 +54,9 @@ Knock Airport is north of Galway City and can be accessed by bus services. It is
 ### Hotels
 Galway Features a Number of Hotels that are proximate to the University. Attendees are encouraged to book early. Local options Include, Hotels, Guesthouses, Air B&B and Hostels. If attendees are booking late or experience difficulties booking please contact the organisers and alternative room provision can be arranged.
 
-* Maldron Hotel Sandy Road (Five Minutes Taxi Journey from J.E Cairnes School): https://www.maldronhotelsandyroadgalway.com/ 
-* Salthill Hotel (Ten Minutes Taxi Journey from J.E Cairnes School): https://www.salthillhotel.com/ 
-* Jurys Inn, Galway (Within several minutes walk of the South Campus): https://www.jurysinns.com/hotels/galway 
+* [Maldron Hotel Sandy Road](https://www.maldronhotelsandyroadgalway.com/) (Five Minutes Taxi Journey from J.E Cairnes School)
+* [Salthill Hotel](https://www.salthillhotel.com/) (Ten Minutes Taxi Journey from J.E Cairnes School)
+* [Jurys Inn, Galway](https://www.jurysinns.com/hotels/galway) (Within several minutes walk of the South Campus)
 * Asgard Guesthouse (Ten Minutes Taxi Journey from J.E Cairnes School)
 
 Other Hotels & Hostels in Galway City:

--- a/pages/gdrive.md
+++ b/pages/gdrive.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource Commons Google Drive'
+permalink: "/gdrive/"
+redirect_to: 
+    - https://drive.google.com/drive/folders/0B2FGN9Kd_fgSMDhJU1Nna0Njbm8
+---

--- a/pages/ggroup.md
+++ b/pages/ggroup.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource Commons Google Group'
+permalink: "/ggroup/"
+redirect_to: 
+    - https://groups.google.com/forum/#!forum/innersource-commons
+---

--- a/pages/springsummit2019.md
+++ b/pages/springsummit2019.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource Spring Summit 2019'
+permalink: "/springsummit2019/"
+redirect_to: 
+    - http://paypal.github.io/InnerSourceCommons/events/isc-spring-2019/
+---

--- a/pages/springsummit2019_cfp.md
+++ b/pages/springsummit2019_cfp.md
@@ -1,0 +1,8 @@
+---
+layout: page
+show_meta: false
+title: 'InnerSource Spring Summit 2019 Call for Presentations'
+permalink: "/springsummit2019_cfp/"
+redirect_to: 
+    - http://paypal.github.io/InnerSourceCommons/events/isc-spring-2019-cfp/
+---


### PR DESCRIPTION
This is to update the ISC site sidebar and events pages + adding quick links for the google group and google drive (protected via google group membership).