### PR TITLE
Fix "other hotels" rendering

### DIFF
--- a/events/isc-spring-2019.md
+++ b/events/isc-spring-2019.md
@@ -60,6 +60,7 @@ Galway Features a Number of Hotels that are proximate to the University. Attende
 * Asgard Guesthouse (Ten Minutes Taxi Journey from J.E Cairnes School)
 
 Other Hotels & Hostels in Galway City:
+
 * Raddison Blu Hotel
 * Park House Hotel
 * Meyrick Hotel


### PR DESCRIPTION
Bulleted lists in markdown syntax require a newline before the list in order to render properly.
_GitHub_ is forgiving and renders properly even without that newline, but some static site generators do not.

Here's the rendering from [the current event page](https://paypal.github.io/InnerSourceCommons/events/isc-spring-2019/).

<img width="653" alt="screen shot 2019-02-01 at 2 11 43 pm" src="https://user-images.githubusercontent.com/9609562/52152551-9793b600-262b-11e9-981a-52a59d720f9e.png">
