### PR TITLE
removed links to wiki

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -25,8 +25,6 @@
     url: "/resources/books"
   - title: "Learning Path"
     url: "/resources/learningpath/"
-  - title: "Wiki"
-    url: "https://github.com/paypal/InnerSourceCommons/wiki"
   - title: "Patterns"
     url: "/patterns/"
   - title: "Events"
@@ -45,10 +43,6 @@
 
 - title: "About"
   url: "/about/"
-  side: left
-
-- title: "Wiki"
-  url: "/wiki/"
   side: left
 
 - title: "Patterns"

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -30,8 +30,6 @@
       <a href="https://github.com/paypal/InnerSourceCommons/issues"><img src="https://img.shields.io/github/issues/paypal/InnerSourceCommons.svg" alt="Issues"></a>
       <br />
       <a href="https://github.com/paypal/InnerSourceCommons"><img src="https://img.shields.io/github/forks/paypal/InnerSourceCommons.svg?style=social&label=Fork" alt="Fork"></a>
-      <br />
-      Check out the <a href="https://github.com/paypal/InnerSourceCommons/wiki">InnerSource Commons wiki</a>!
     </p>
   </div>
 </aside>

--- a/resources/index.md
+++ b/resources/index.md
@@ -13,10 +13,6 @@ Academic papers, news articles, blogs
   * [Understanding the InnerSource Checklist]({{ site.baseurl }}/checklist/)
   * [Adopting InnerSource - Principles and Case Studies](books/adoptinginnersource)
 
-### [InnerSource Commons Wiki](https://github.com/paypal/InnerSourceCommons/wiki)
-
-Checklists, definitions, and all the other random, uncategorized stuff
-
 ### [Events](/InnerSourceCommons/events/)
 
 Meet up with other folks working to implement InnerSource in their organizations


### PR DESCRIPTION
I as a ISC newcomer was misled by the widespread use of links to Wiki on GitHub, but the information there is very outdated, and all useful articles have already moved to the repository itself.