### PR TITLE
Removed floating (duplicate) _show abstract_ from before Thursday's heading

### DIFF
--- a/events/isc-spring-2019-agenda.md
+++ b/events/isc-spring-2019-agenda.md
@@ -312,8 +312,6 @@ Crowdsourcing is emerging as an alternative outsourcing strategy which is gainin
 
         <td class="author">
 <a href="/InnerSourceCommons/events/isc-spring-2019-speakers#daniel_izquierdo_cortázar">Daniel Izquierdo Cortázar</a> <span class="affiliation">(Bitergia)</span></td>
-     <span onClick="toggleAbstract('cortázar-2')" class="abstract-toggle">(<a id="cortázar-2-link">Show Abstract</a>)</span>
-
 <td class="title">Metrics and KPIs for an InnerSource Office 
      <span onClick="toggleAbstract('cortázar-2')" class="abstract-toggle">(<a id="cortázar-2-link">Show Abstract</a>)</span>
 <div style="display:none" class="abstract" id="cortázar-2">


### PR DESCRIPTION
The rendered page has a duplicate, floating _Show Abstract_ link just before Thursday's heading:
![image](https://user-images.githubusercontent.com/1150270/54683716-46bc1c00-4b0a-11e9-90e4-2c9950dd246b.png)

This change should remove that.